### PR TITLE
Remove warnings about shadowing clojure.core/abs

### DIFF
--- a/README.org
+++ b/README.org
@@ -86,7 +86,7 @@ target/math-<<version>>.js
 #+END_SRC
 **** [[https://github.com/clojure/clojurescript][ClojureScript]]
 #+BEGIN_SRC clojure :noweb-ref dep-cljs
-[org.clojure/clojurescript "1.11.4"]
+[org.clojure/clojurescript "1.11.54"]
 #+END_SRC
 **** [[https://github.com/thi-ng/typedarrays/][thi.ng/typedarrays]]
 #+NAME: dep-tarrays

--- a/src/bits.org
+++ b/src/bits.org
@@ -177,7 +177,7 @@ http://graphics.stanford.edu/~seander/bithacks.html
 
 #+BEGIN_SRC clojure :tangle ../babel/src/thi/ng/math/bits.cljc :noweb yes :mkdirp yes :padline no
   (ns thi.ng.math.bits
-    (:refer-clojure :exclude [bit-count]))
+    (:refer-clojure :exclude [abs bit-count]))
 
   <<const>>
 

--- a/src/core.org
+++ b/src/core.org
@@ -208,10 +208,7 @@ to math operations across several other [[http://thi.ng/][thi.ng]] projects, mos
 *** Absolute value & difference
 
 #+BEGIN_SRC clojure :noweb-ref math
-  #?(:clj
-     (defn abs* [x] (if (neg? x) (clojure.core/- x) x))
-     :cljs
-     (def abs* Math/abs))
+  (def abs* clojure.core/abs)
 
   (defn abs-diff
     [x y] (abs* (mm/sub x y)))
@@ -604,7 +601,7 @@ to math operations across several other [[http://thi.ng/][thi.ng]] projects, mos
 
 #+BEGIN_SRC clojure :tangle ../babel/src/thi/ng/math/core.cljc :noweb yes :mkdirp yes :padline no
   (ns thi.ng.math.core
-    (:refer-clojure :exclude [+ - * min max bit-count])
+    (:refer-clojure :exclude [+ - * abs bit-count min max])
     #?(:clj
        (:require [thi.ng.math.macros :as mm])
        :cljs


### PR DESCRIPTION
Replaces abs* definition with clojure.core/abs, and excludes abs from
thi.ng/math/bits and thi.ng/math/core to prevent warnings like:

    WARNING: abs already refers to: #'clojure.core/abs in namespace: thi.ng.math.bits, being replaced by: #'thi.ng.math.bits/abs

and

    Warning: protocol #'thi.ng.math.core/IMathOps is overwriting function abs

Finally, bumps dependency for Clojurescript to 1.11.54 as abs was added in
https://github.com/clojure/clojurescript/commit/6e0bd78b62e3d72874614a4634d82c19e9dfd66d

Clojure 1.11.1 already implemented abs in:
https://github.com/clojure/clojure/commit/ff61321179a0b0f7d2c17a394ade80465ac15c28

Previously tests reported the warnings like:
```
  $ ./tangle.sh src/*.org test/*.org
  ... elided ...
  $ cd babel
  $ lein test
  Warning: protocol #'thi.ng.math.core/IMathOps is overwriting function abs
  WARNING: abs already refers to: #'clojure.core/abs in namespace: thi.ng.math.core, being replaced by: #'thi.ng.math.core/abs

  lein test thi.ng.math.test.core

  lein test thi.ng.math.test.macros

  Ran 17 tests containing 130 assertions.
  0 failures, 0 errors.
```

now tests pass like;
```
  $ ./tangle.sh src/*.org test/*.org
  ... elided ...
  $ cd babel
  $ lein test

  lein test thi.ng.math.test.core

  lein test thi.ng.math.test.macros

  Ran 17 tests containing 130 assertions.
  0 failures, 0 errors.
```

However, I was unable to run the Clojurescript tests using `lein cleantest`. Both with and without the patch, the runner would hang after printing the line `Running ClojureScript test: unit-tests`. I might take a look at upgrading to cljs.test from cemerick.cljs.test and using a different runner, but that seemed out of scope for this change.